### PR TITLE
Implement Slash Commands

### DIFF
--- a/faq/index.js
+++ b/faq/index.js
@@ -82,12 +82,19 @@ module.exports =
         memberName: 'faq',
         description: 'Look up an entry in the Lancer FAQ/Errata, available here: https://lancer-faq.netlify.app',
         argsType: 'single',
-        guildOnly: false
+        guildOnly: false,
+        interactions: [{ type: "slash" }],
+        args: [{
+          type: "string",
+          prompt: "Look up an entry in the Lancer FAQ/Errata.",
+          key: "question"
+        }]
       })
     }
     async run(msg, arg) {
-      console.log(arg);
-      const out = await getQuestion(arg);
+      const question = arg.question
+      console.log(question);
+      const out = await getQuestion(question);
       await msg.reply(out, { split: true })
     }
   }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class DmCommand extends Commando.Command {
       memberName: 'dm-me',
       aliases: ['dm_me', 'enable-dms', 'enable_dms', 'enable-dm', 'enable_dm'],
       description: 'UNCLEBot DMs you one message, enabling you to send commands via DM.',
-      guildOnly: false,
+      guildOnly: true,
       interactions: [{ type: "slash" }]
     })
   }
@@ -57,7 +57,7 @@ class SearchCommand extends Commando.Command {
       description: 'Searches the LANCER compendium, including supplements.',
       defaultHandling: false,
       throttling: false,
-      guildOnly: false,
+      guildOnly: true,
       interactions: [{ type: "slash" }],
       argsType: "single",
       args: [{
@@ -101,7 +101,7 @@ class InviteCommand extends Commando.Command {
       group: 'lancer',
       memberName: 'invite',
       description: 'Get an invite link for UNCLE',
-      guildOnly: false,
+      guildOnly: true,
       interactions: [{ type: "slash" }]
     })
     client.on('ready', () => this.userID = client.user.id)
@@ -121,7 +121,7 @@ class StructureCommand extends Commando.Command {
       group: 'lancer',
       memberName: 'structure',
       description: 'Look up an entry on the structure check table.', // Parameters: Lowest dice rolled, Mech's remaining structure
-      guildOnly: false,
+      guildOnly: true,
       interactions: [{ type: "slash" }],
       args: [
         {
@@ -151,7 +151,7 @@ class StressCommand extends Commando.Command {
       group: 'lancer',
       memberName: 'stress',
       description: 'Look up an entry on the Stress/Overheating table.', //  Parameters: Lowest dice rolled, Mech's remaining stress
-      guildOnly: false,
+      guildOnly: true,
       interactions: [{ type: "slash" }],
       args: [
         {

--- a/index.js
+++ b/index.js
@@ -216,9 +216,9 @@ client.registry
 
 client.login(process.env.TOKEN)
     .then(async () => {
-      client.guilds.cache.forEach((guild) => {
+      client.guilds.cache.map(async (guild) => {
         console.log(`registering commands to guild ${guild.id}`)
-        client.registry.registerSlashInGuild(guild)
+        await client.registry.registerSlashInGuild(guild)
       })
 
       client.on("guildCreate", async (guild) => {


### PR DESCRIPTION
* add interaction type in command declarations
* codify args for those that were not specified
* access args properly once codified (via args property in run method)
* update activity to no longer specify brackets
* reply to /dm-me command both where it is used and via dms
  * **note that slash commands cannot be used in dms**, but the same commands as before _can_ be. rather than registering slash commands globally (which includes dms), register them by the guilds that the bot has been added to, both on login and when added to a new guild
* modify the search command as it can no longer support multiple queries in a single message
* modify the search command as it can no longer reply to a slash command message multiple times (e.g., to support apocalypse rail)
* trim descriptions that are long enough to crash discord api
* register slash commands globally only after login