### PR TITLE
Flyio+fix slashes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# flyctl launch added from .gitignore
+**\node_modules
+**\.env
+**\.idea
+**\data\*.lcp
+
+# flyctl launch added from .idea\.gitignore
+# Default ignored files
+.idea\shelf
+.idea\workspace.xml
+# Editor-based HTTP Client requests
+.idea\httpRequests
+fly.toml

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,44 @@
+# fly.toml file generated for lancer-uncle on 2023-01-24T14:04:21-06:00
+
+app = "lancer-uncle"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[build]
+  builder = "heroku/buildpacks:20"
+
+[env]
+  PORT = "8080"
+
+[experimental]
+  auto_rollback = true
+
+# Currently the healthchecks fail probably because they can't find a port.
+# The app seems to run fine though so it's not a pressing issue to me.
+
+[[services]]
+  http_checks = []
+  internal_port = 8080
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ class SearchCommand extends Commando.Command {
     }
     
     const results = targets.map(tgt => {
-      //Entry point for searches.
+      // Entry point for searches.
       const results = search(tgt.term, tgt.category)
       if (results.length === 0) return `No results found for *${(tgt.category || '')}${tgt.term.replace(/@/g, '\\@')}*.`
       else return format(results[0].item)
@@ -96,7 +96,7 @@ class SearchCommand extends Commando.Command {
 
   splitCommandArg(searchTerm) {
     let targets = [];
-    //Identify a searchable term.
+    // Identify a searchable term.
     const matches = searchTerm.split(":")
     if (matches.length > 1) {
       targets.push({term: matches[1], category: matches[0]})
@@ -137,7 +137,7 @@ class InviteCommand extends Commando.Command {
     client.on('ready', () => this.userID = client.user.id)
   }
   async run(msg) {
-    await msg.reply(`Invite me to your server: https://discordapp.com/api/oauth2/authorize?client_id=${this.userID}&permissions=76800&scope=bot`)
+    await msg.reply(`Invite me to your server: https://discordapp.com/api/oauth2/authorize?client_id=${this.userID}&permissions=2147483648&scope=bot`)
   }
 }
 
@@ -150,7 +150,7 @@ class StructureCommand extends Commando.Command {
       aliases: ['structure-check', 'structure_check', 'structure-damage', 'structure_damage'],
       group: 'lancer',
       memberName: 'structure',
-      description: 'Look up an entry on the structure check table.', // Parameters: Lowest dice rolled, Mech's remaining structure
+      description: 'Look up an entry on the Structure check table.', // Parameters: Lowest dice rolled, Mech's remaining structure
       guildOnly: false,
       interactions: [{ type: "slash" }],
       args: [
@@ -221,7 +221,9 @@ client.login(process.env.TOKEN)
     })
 
 // this is a hack, liable to break. I would use client.registry.registerSlashGlobally() but that's really slow
-// for some reason. also the search-compendium command doesn't work in DMs but it works in guilds. why.
+// for some reason. bugs:
+// -the search-compendium command doesn't work in DMs but it works in guilds. why.
+// -every DM command needs to NOT be prefixed with a slash and it will work. what.
 async function registerCommandsToAllGuilds() {
   // const commands = client.registry._prepareCommandsForSlash()
 

--- a/index.js
+++ b/index.js
@@ -222,8 +222,6 @@ client.login(process.env.TOKEN)
 // bugs:
 // -every DM command needs to NOT be prefixed with a slash and it will work. what.
 async function registerCommandsToAllGuilds() {
-  // const commands = client.registry._prepareCommandsForSlash()
-
   const commands = client.registry._prepareCommandsForSlash().map((command) => {
     // slash commands are type 1
     if (command.type === 1) {

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ class SearchCommand extends Commando.Command {
       group: 'lancer',
       memberName: 'search',
       aliases: ['search', 'compendium'],
-      description: 'Searches the LANCER compendium, including supplements. **(Use "search" for short.)**',
+      description: 'Searches the LANCER compendium, including supplements.',
       throttling: false,
       guildOnly: false,
       interactions: [{ type: "slash" }],

--- a/index.js
+++ b/index.js
@@ -220,17 +220,20 @@ client.login(process.env.TOKEN)
       await registerCommandsToAllGuilds()
     })
 
-// this is a hack, liable to break. it is based on the implementation of client.registry.registerSlashGlobally(),
-// but it explicitly sets dm_permission for slash commands to false, which commando does not support doing.
+// this is a hack, liable to break. I would use client.registry.registerSlashGlobally() but that's really slow
+// for some reason. also the search-compendium command doesn't work in DMs but it works in guilds. why.
 async function registerCommandsToAllGuilds() {
+  // const commands = client.registry._prepareCommandsForSlash()
+
   const commands = client.registry._prepareCommandsForSlash().map((command) => {
     // slash commands are type 1
     if (command.type === 1) {
-      return { ...command, dm_permission: false }
+      return { ...command, dm_permission: true }
     } else {
       return command
     }
   })
+  console.log(commands)
 
   await client.registry.rest.put(
       Routes.applicationCommands(client.user.id),

--- a/index.js
+++ b/index.js
@@ -55,9 +55,7 @@ class SearchCommand extends Commando.Command {
       group: 'lancer',
       memberName: 'search',
       aliases: ['search', 'compendium'],
-      description: 'Searches the LANCER compendium, including supplements.',
-      patterns: [/\[\[(.+:)?(.+?)\]\]/],
-      defaultHandling: false,
+      description: 'Searches the LANCER compendium, including supplements. **(Use "search" for short.)**',
       throttling: false,
       guildOnly: false,
       interactions: [{ type: "slash" }],
@@ -220,9 +218,8 @@ client.login(process.env.TOKEN)
       await registerCommandsToAllGuilds()
     })
 
-// this is a hack, liable to break. I would use client.registry.registerSlashGlobally() but that's really slow
-// for some reason. bugs:
-// -the search-compendium command doesn't work in DMs but it works in guilds. why.
+// this is a hack, liable to break. I would use client.registry.registerSlashGlobally() but that's really slow.
+// bugs:
 // -every DM command needs to NOT be prefixed with a slash and it will work. what.
 async function registerCommandsToAllGuilds() {
   // const commands = client.registry._prepareCommandsForSlash()


### PR DESCRIPTION
* host code on fly.io
* fix slash commands and stuff

Weirdness:
* needed to reinvite lancer-cc-uncle-demo (a personal bot) using a new permission integer (2147483648 instead of 78400)... however, UNCLE did not need to be reinvited (at least on first glance).
* Slash commands sort of work in DMs, but, only if you don't use slashes. 
  * i.e. first send `/dm-me` in a guild channel, as previous
  * then do just `search` or `faq` without the slash prefix. 
* Split messages don't work (it'll only send the first message of the chain. try with `black thumb` or `apoc rail`)/work very inconsistently, though they mostly just don't work.
