### PR TITLE
Fix slash failures in DMs/forums by acknowledging interactions.

### DIFF
--- a/faq/index.js
+++ b/faq/index.js
@@ -1,5 +1,6 @@
 const Commando = require('@iceprod/discord.js-commando')
 const Fuse = require('fuse.js')
+const { Util } = require('discord.js')
 
 
 const getFaqData = require('./getFaq')
@@ -95,6 +96,15 @@ module.exports =
       const question = arg.question
       console.log(question);
       const out = await getQuestion(question);
-      await msg.reply(out, { split: true })
+      // For slash interactions, reply via interaction API to ensure the UI is acknowledged.
+      if (msg.interaction) {
+        const parts = Util.splitMessage(out)
+        await msg.interaction.reply({ content: parts[0] })
+        for (let i = 1; i < parts.length; ++i) {
+          await msg.interaction.followUp({ content: parts[i] })
+        }
+      } else {
+        await msg.reply(out, { split: true })
+      }
     }
   }

--- a/index.js
+++ b/index.js
@@ -42,9 +42,17 @@ class DmCommand extends Commando.Command {
     })
   }
   async run(msg) {
-      msg.reply("Adding your DM to my cached channels.").then(async () => {
-          await msg.author.send("Added your DM to my cached channels. You can now DM me commands.")
-      })
+      // Acknowledge the interaction first to avoid failing slash commands in DMs/forums.
+      const notify = "Adding your DM to my cached channels.";
+      if (msg.interaction) {
+          // In DMs and forum threads, using interaction.reply ensures the platform
+          // receives an acknowledgement and prevents "interaction failed".
+          await msg.interaction.reply({ content: notify });
+      } else {
+          await msg.reply(notify);
+      }
+      // Then DM the user to prime the DM channel cache (Discord.js quirk described in README).
+      await msg.author.send("Added your DM to my cached channels. You can now DM me commands.")
   }
 }
 
@@ -86,9 +94,17 @@ class SearchCommand extends Commando.Command {
     }).join('\n--\n')
     
     const splitMessages = Util.splitMessage('\n' + results)
-    let currentMessage = msg
-    for (let i = 0; i < splitMessages.length; ++i) {
-      currentMessage = await currentMessage.reply(splitMessages[i])
+    if (msg.interaction) {
+      // Use interaction API to ensure the slash interaction is acknowledged in DMs/threads.
+      await msg.interaction.reply({ content: splitMessages[0] })
+      for (let i = 1; i < splitMessages.length; ++i) {
+        await msg.interaction.followUp({ content: splitMessages[i] })
+      }
+    } else {
+      let currentMessage = msg
+      for (let i = 0; i < splitMessages.length; ++i) {
+        currentMessage = await currentMessage.reply(splitMessages[i])
+      }
     }
   }
 
@@ -135,7 +151,16 @@ class InviteCommand extends Commando.Command {
     client.on('ready', () => this.userID = client.user.id)
   }
   async run(msg) {
-    await msg.reply(`Invite me to your server: https://discordapp.com/api/oauth2/authorize?client_id=${this.userID}&permissions=2147483648&scope=bot`)
+    // Prefer interaction replies so the slash interaction is properly acknowledged
+    // in DMs and forum threads (avoids "This interaction failed"). Also update the
+    // invite URL to include applications.commands scope so slash commands can be registered.
+    const invite = `Invite me to your server: https://discord.com/oauth2/authorize?client_id=${this.userID}&permissions=2147483648&scope=bot%20applications.commands`;
+    if (msg.interaction) {
+      // Ephemeral reduces noise in busy channels; safe in DMs as well (Discord ignores ephemeral in DMs)
+      await msg.interaction.reply({ content: invite, ephemeral: true });
+    } else {
+      await msg.reply(invite);
+    }
   }
 }
 
@@ -167,7 +192,13 @@ class StructureCommand extends Commando.Command {
   }
   
   async run(msg, {lowest_dice_roll, structure_remaining}) {
-    await msg.reply(structureDamage(lowest_dice_roll, structure_remaining))
+    const out = structureDamage(lowest_dice_roll, structure_remaining)
+    // Prefer interaction replies to avoid failed slash interactions in DMs/threads
+    if (msg.interaction) {
+      await msg.interaction.reply({ content: out })
+    } else {
+      await msg.reply(out)
+    }
   }
 }
 
@@ -197,7 +228,13 @@ class StressCommand extends Commando.Command {
   }
   
   async run(msg, {lowest_dice_roll, stress_remaining}) {
-    await msg.reply(stressDamage(lowest_dice_roll, stress_remaining))
+    const out = stressDamage(lowest_dice_roll, stress_remaining)
+    // Prefer interaction replies to avoid failed slash interactions in DMs/threads
+    if (msg.interaction) {
+      await msg.interaction.reply({ content: out })
+    } else {
+      await msg.reply(out)
+    }
   }
 }
 
@@ -223,9 +260,17 @@ client.login(process.env.TOKEN)
 // -every DM command needs to NOT be prefixed with a slash and it will work. what.
 async function registerCommandsToAllGuilds() {
   const commands = client.registry._prepareCommandsForSlash().map((command) => {
-    // slash commands are type 1
+    // Slash commands are type 1. Explicitly enable DMs and opt into new contexts
+    // so commands are available in DMs and private channels. Note: contexts and
+    // integration_types are part of newer Discord features; older API layers may
+    // ignore these fields without error.
     if (command.type === 1) {
-      return { ...command, dm_permission: true }
+      return {
+        ...command,
+        dm_permission: true,                 // legacy DM toggle for older behavior
+        contexts: [0, 1, 2],                 // 0: GUILD, 1: BOT_DM, 2: PRIVATE_CHANNEL
+        integration_types: [0]               // 0: GUILD_INSTALL; add 1 for USER_INSTALL if desired
+      }
     } else {
       return command
     }


### PR DESCRIPTION
Hello! Big fan of the bot, had an annoying issue where the bot couldn't use slash commands properly in forum channels primarily, and I wanted to fix it.

There's some comments towards the bottom about the implementation of `registerCommandsToAllGuilds` that was altered, but my primary objective was to fix the interactions contexts. Let me know if you want/need anything in this PR or reach out to me on discord: ilikemotorcycles

Thanks!